### PR TITLE
Compatibilité Bbox OS 23.8.16

### DIFF
--- a/custom_components/bbox/config_flow.py
+++ b/custom_components/bbox/config_flow.py
@@ -48,8 +48,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 await api.async_login()
                 infos = await api.device.async_get_bbox_summary()
-                if sn := infos.get("device", {}).get("serialnumber") is None:
-                    raise CannotConnect("Serial number of device not found")
+
+                try:
+                    sn = infos[0]["device"]["serialnumber"]
+                    assert sn is not None, "Null Bbox serial number retrieved"
+                except (IndexError, KeyError, AssertionError) as err:
+                    raise CannotConnect("Serial number of device not found") from err
 
                 await self.async_set_unique_id(sn)
                 self._abort_if_unique_id_configured()

--- a/custom_components/bbox/helpers.py
+++ b/custom_components/bbox/helpers.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.typing import StateType
 class BboxSensorDescription(SensorEntityDescription):
     """Describes a sensor."""
 
+    get_value: Callable[..., Any] | None = None
     value_fn: Callable[..., StateType] | None = None
 
 


### PR DESCRIPTION
Je compile ici un ensemble de correction faites pour rétablir la compatibilité avec ma Bbox utilisant le firmware 23.8.16 (du 17/06/2024) :

* Il y avait un problème lors de la récupération du firmware lors de la configuration initiale (`infos[0]["device"]["serialnumber"]` vs `infos["device"]["serialnumber"]`)
* Lors de la récupération des équipements (`bbox.lan.async_get_connected_devices()`), il y a plus d'un élément à la racine. Dans les faits, tous les équipements sont dans le premier élément, mais il y a également un second élément : `{"hosts":{"list":[]}}`. C'est peut-être un bug de la Bbox, mais dans le doute, j'ai implémenté une méthode de _merge_ de tous les éléments retournés.
* j'ai corrigé les capteurs du WAN qui ne correspondait pas à la réalité des données remontées par la box :

  - la clé `bytes` correspond au total des données téléchargées/envoyées et non plus au trafic instantané qu'on retrouve dans la clé `bandwidth`
  - la clé `occupation` n'est pas un pourcentage, mais la même valeur que `bandwidth` divisée par 100. Pour obtenir un réel taux d'occupation, j'ai implémenté une entité faisant un produit en croix entre `bandwidth` et `maxBandwidth`. Par ailleurs, l'unité `%` sur une entité portant la classe `DATA_RATE` génère une erreur. Il n'y a pas vraiment de bonne classe [prévu par Home Assistant](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes), donc j'ai pris ce qui se rapprochait le plus selon moi et acceptant l'unité `%` (`POWER_FACTOR`).

Ci-dessous un exemple de données retourné par `bbox.wan.async_get_wan_ip_stats()` sur ma Bbox :

```json
[
  {
    "wan": {
      "ip": {
        "stats": {
          "rx": {
            "packets": 223669411,
            "bytes": "276015189891",
            "packetserrors": 0,
            "packetsdiscards": 0,
            "occupation": 78,
            "bandwidth": 7844,
            "maxBandwidth": 1000000
          },
          "tx": {
            "packets": 23730913,
            "bytes": "5918730974",
            "packetserrors": 0,
            "packetsdiscards": 0,
            "occupation": 6,
            "bandwidth": 673,
            "maxBandwidth": 1000000
          }
        }
      }
    }
  }
]
```

__Note :__ pour que cela fonctionne, ma [PR](https://github.com/cyr-ius/bboxpy/pull/43) sur la lib `bboxpy` est également nécessaire.