### PR TITLE
Ajout de switchs pour gérer l'état du service de contrôle d'accès

### DIFF
--- a/custom_components/bbox/__init__.py
+++ b/custom_components/bbox/__init__.py
@@ -15,6 +15,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.DEVICE_TRACKER,
     Platform.BUTTON,
+    Platform.SWITCH,
 ]
 
 

--- a/custom_components/bbox/coordinator.py
+++ b/custom_components/bbox/coordinator.py
@@ -43,6 +43,7 @@ class BboxDataUpdateCoordinator(DataUpdateCoordinator):
             bbox_info = self.check_list(await self.bbox.device.async_get_bbox_info())
             devices = self.check_list(await self.bbox.lan.async_get_connected_devices())
             wan_ip_stats = self.check_list(await self.bbox.wan.async_get_wan_ip_stats())
+            parentalcontrol = self.check_list(await self.bbox.parentalcontrol.async_get_parental_control_service_state())
             # wan = self.check_list(await self.bbox.wan.async_get_wan_ip())
             # iptv_channels_infos = self.check_list(await self.bbox.iptv.async_get_iptv_info())
             # lan_stats = self.check_list(await self.bbox.lan.async_get_lan_stats())
@@ -56,6 +57,7 @@ class BboxDataUpdateCoordinator(DataUpdateCoordinator):
             "info": bbox_info,
             "devices": devices,
             "wan_ip_stats": wan_ip_stats,
+            "parentalcontrol": parentalcontrol,
             # "wan": wan,
             # "iptv_channels_infos": iptv_channels_infos,
             # "lan_stats": lan_stats,

--- a/custom_components/bbox/entity.py
+++ b/custom_components/bbox/entity.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
+from homeassistant.helpers import device_registry
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -14,7 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class BboxEntity(CoordinatorEntity[BboxDataUpdateCoordinator], Entity):
-    """Base class for all entities."""
+    """Base class for all Bbox entities."""
 
     _attr_has_entity_name = True
 
@@ -35,4 +37,49 @@ class BboxEntity(CoordinatorEntity[BboxDataUpdateCoordinator], Entity):
             "model": device.get("modelname"),
             "sw_version": device.get("main", {}).get("version"),
             "configuration_url": f"https://{coordinator.config_entry.data[CONF_HOST]}",
+        }
+
+class BboxDeviceEntity(BboxEntity):
+    """Base class for all device's entities connected to the Bbox"""
+
+    def __init__(
+        self,
+        coordinator: BboxDataUpdateCoordinator,
+        description: EntityDescription,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, description)
+        self._device = device
+        self._device_key = f"{self.box_id}_{device['macaddress'].replace(':', '_')}"
+        if self._device.get("userfriendlyname", "") != "":
+            self._device_name = device["userfriendlyname"]
+        elif self._device.get("hostname") != "":
+            self._device_name = device["hostname"]
+        else:
+            self._device_name = device["macaddress"]
+        self._attr_device_info = {
+            "name": self._device_name,
+            "identifiers": {(DOMAIN, self._device_key)},
+            "connections": {(device_registry.CONNECTION_NETWORK_MAC, device["macaddress"])},
+            "via_device": (DOMAIN, self.box_id),
+        }
+
+    @property
+    def coordinator_data(self):
+        """Return connecting status."""
+        for device in (
+            self.coordinator.data.get("devices", {}).get("hosts", {}).get("list", [])
+        ):
+            if device["macaddress"] == self._device["macaddress"]:
+                return device
+        return {}
+
+    @property
+    def extra_state_attributes(self):
+        """Return extra attributes."""
+        return {
+            "link": self._device.get("link"),
+            "last_seen": self._device.get("lastseen"),
+            "ip_address": self._device.get("ipaddress"),
         }

--- a/custom_components/bbox/switch.py
+++ b/custom_components/bbox/switch.py
@@ -1,0 +1,142 @@
+"""Button for Bbox router."""
+
+import asyncio
+import logging
+
+from typing import Any
+
+from bboxpy.exceptions import BboxException
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import BBoxConfigEntry, BboxDataUpdateCoordinator
+from .entity import BboxEntity, BboxDeviceEntity
+from .helpers import finditem
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: BBoxConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up sensor."""
+    coordinator = entry.runtime_data
+    description = SwitchEntityDescription(
+        key="parental_control",
+        translation_key="parental_control",
+        name="Parental control",
+        icon="mdi:security"
+    )
+    devices = coordinator.data.get("devices", {}).get("hosts", {}).get("list", [])
+    entities = [
+        DeviceParentalControlSwitch(coordinator, description, device)
+        for device in devices
+        if device.get("macaddress")
+    ]
+    entities += [ParentalControlServiceSwitch(coordinator, description)]
+    async_add_entities(entities)
+
+
+class ParentalControlServiceSwitch(BboxEntity, SwitchEntity):
+    """Representation of a switch for Bbox parental control service state."""
+    
+    waiting_delay_after_toggle = 5
+
+    def __init__(
+        self,
+        coordinator: BboxDataUpdateCoordinator,
+        description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, description)
+
+        self._attr_name = "Parental control"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if parental control service is currently enabled."""
+        return bool(
+            finditem(self.coordinator.data, "parentalcontrol.parentalcontrol.scheduler.enable")
+        )
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        try:
+            await self.coordinator.bbox.parentalcontrol.async_set_parental_control_service_state(
+                enable=True
+            )
+        except BboxException as error:
+            _LOGGER.error(error)
+            return
+        _LOGGER.debug(
+            "Request sent, we need to wait a bit (%ds) before updating state...",
+            self.waiting_delay_after_toggle
+        )
+        await asyncio.sleep(self.waiting_delay_after_toggle)
+        _LOGGER.debug("Updating state")
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the switch off."""
+        try:
+            await self.coordinator.bbox.parentalcontrol.async_set_parental_control_service_state(
+                enable=False
+            )
+        except BboxException as error:
+            _LOGGER.error(error)
+            return
+        _LOGGER.debug(
+            "Request sent, we need to wait a bit (%ds) before updating state...",
+            self.waiting_delay_after_toggle
+        )
+        await asyncio.sleep(self.waiting_delay_after_toggle)
+        _LOGGER.debug("Updating state")
+        await self.coordinator.async_request_refresh()
+
+
+class DeviceParentalControlSwitch(BboxDeviceEntity, SwitchEntity):
+    """Representation of a switch for device parental control state."""
+
+    def __init__(
+        self,
+        coordinator: BboxDataUpdateCoordinator,
+        description: SwitchEntityDescription,
+        device: dict[str, Any],
+    ) -> None:
+        """Initialize."""
+        super().__init__(coordinator, description, device)
+
+        self._attr_name = "Parental control"
+        self._attr_unique_id = f"{self._device_key}_parental_control"
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device parental control is currently enabled."""
+        return bool(finditem(self.coordinator_data, "parentalcontrol.enable"))
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the switch on."""
+        try:
+            await self.coordinator.bbox.parentalcontrol.async_set_device_parental_control_state(
+                macaddress= self._device["macaddress"],
+                enable=True
+            )
+        except BboxException as error:
+            _LOGGER.error(error)
+            return
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the switch off."""
+        try:
+            await self.coordinator.bbox.parentalcontrol.async_set_device_parental_control_state(
+                macaddress= self._device["macaddress"],
+                enable=False
+            )
+        except BboxException as error:
+            _LOGGER.error(error)
+            return
+        await self.coordinator.async_request_refresh()
+        


### PR DESCRIPTION
Il s'agit là d'une nouvelle fonctionnalité tirant partie de ma [PR](https://github.com/cyr-ius/bboxpy/pull/44) sur la lib `bboxpy`. Cela ajoute :
* une entité _switch_ au niveau de la Bbox pour gérer l'état du service __Contrôle d'accès_ de la Bbox (appelé `parentalcontrol` par l'API)
* une entité _switch_ au niveau de chaque équipement pour contrôlé s'il est concerné ou non par le contrôle d'accès

Pour que l'entité _device_tracker_ de l'équipement soit vu comme relatif au même appareil dans HA, j'ai également repris ce type d'entités. J'ai réuni au passage tout ce qu'il y a en commun entre ces entités dans une classe commune `BboxDeviceEntity`.