### PR TITLE
unité de mesure invalide pour `sensor.bbox_memory_free`

### DIFF
--- a/custom_components/bbox/sensor.py
+++ b/custom_components/bbox/sensor.py
@@ -168,7 +168,7 @@ SENSOR_TYPES: tuple[BboxSensorDescription, ...] = (
     BboxSensorDescription(
         key="memory.device.mem.free",
         name="Memory free",
-        device_class=SensorDeviceClass.CURRENT,
+        device_class=SensorDeviceClass.POWER_FACTOR,
         icon="mdi:gauge",
         get_value=lambda self: (
             int(finditem(self.coordinator.data, "memory.device.mem.free") * 100)


### PR DESCRIPTION
> 2025-03-10 21:20:47.039 WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.bbox_memory_free (<class 'custom_components.bbox.sensor.BboxSensor'>) is using native unit of measurement '%' which is not a valid unit for the device class ('current') it is using; expected one of ['A', 'mA']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/cyr-ius/hass-bbox2/issues

J'ai changé le type de classe qui correspond le mieux d'après la [doc home-assistant](https://developers.home-assistant.io/docs/core/entity/sensor/).

Je ne sais pas trop comment tester de mon côté, j'ai juste vu le warning sur mon hass et j'aime bien quand tout est propre :)