### PR TITLE
Force entity and device name to be str

### DIFF
--- a/custom_components/bbox/entity.py
+++ b/custom_components/bbox/entity.py
@@ -60,7 +60,7 @@ class BboxDeviceEntity(BboxEntity):
         else:
             self._device_name = device["macaddress"]
 
-        self._attr_name = self._device_name
+        self._attr_name = str(self._device_name)
         self._attr_unique_id = f"{self._device_key}_device_tracker"
         self._attr_device_info = {
             "name": self._device_name,

--- a/custom_components/bbox/entity.py
+++ b/custom_components/bbox/entity.py
@@ -54,9 +54,9 @@ class BboxDeviceEntity(BboxEntity):
         self._device = device
         self._device_key = f"{self.box_id}_{device['macaddress'].replace(':', '_')}"
         if self._device.get("userfriendlyname", "") != "":
-            self._device_name = device["userfriendlyname"]
+            self._device_name = str(device["userfriendlyname"])
         elif self._device.get("hostname") != "":
-            self._device_name = device["hostname"]
+            self._device_name = str(device["hostname"])
         else:
             self._device_name = device["macaddress"]
 

--- a/custom_components/bbox/entity.py
+++ b/custom_components/bbox/entity.py
@@ -63,7 +63,7 @@ class BboxDeviceEntity(BboxEntity):
         self._attr_name = str(self._device_name)
         self._attr_unique_id = f"{self._device_key}_device_tracker"
         self._attr_device_info = {
-            "name": self._device_name,
+            "name": str(self._device_name),
             "identifiers": {(DOMAIN, self._device_key)},
             "connections": {(dr.CONNECTION_NETWORK_MAC, device["macaddress"])},
             "via_device": (DOMAIN, self.box_id),


### PR DESCRIPTION
To fix https://github.com/cyr-ius/hass-bbox2/issues/76, force entity and device names to be str and not integer when the network device hostname is only digits