### PR TITLE
[Fix] macaddress key error

### DIFF
--- a/custom_components/bbox/entity.py
+++ b/custom_components/bbox/entity.py
@@ -87,7 +87,7 @@ class BboxDeviceEntity(BboxEntity):
             (
                 device
                 for device in devices
-                if device["macaddress"] == self._device["macaddress"]
+                if device["macaddress"] == self._device.get("macaddress", None)
             ),
             {},
         )


### PR DESCRIPTION
This PR fixes the key error : 

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/homeassistant/helpers/update_coordinator.py", line 280, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/local/lib/python3.13/site-packages/homeassistant/helpers/update_coordinator.py", line 491, in _async_refresh
    self.async_update_listeners()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/homeassistant/helpers/update_coordinator.py", line 190, in async_update_listeners
    update_callback()
    ~~~~~~~~~~~~~~~^^
  File "/config/custom_components/bbox/entity.py", line 86, in _handle_coordinator_update
    self._device = next(
                   ~~~~^
        (
        ^
    ...<4 lines>...
        {},
        ^^^
    )
    ^
  File "/config/custom_components/bbox/entity.py", line 90, in <genexpr>
    if device["macaddress"] == self._device["macaddress"]
                               ~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'macaddress'
```

i could not find the root cause of this issue but there seem to be no regression with the fix